### PR TITLE
feature/DEVOPS-update_circleci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,8 +196,8 @@ jobs:
             echo >> ~/.pypirc
             echo "[pypi]" >> ~/.pypirc
             echo "repository:https://upload.pypi.org/legacy/" >> ~/.pypirc
-            echo "username:$PYPI_USERNAME" >> ~/.pypirc
-            echo "password:$PYPI_PASSWORD" >> ~/.pypirc
+            echo "username = __token__" >> ~/.pypirc
+            echo "password = ${PYPI_AUTH_TOKEN}" >> ~/.pypirc
             echo >> ~/.pypirc
             sudo pip install bumpversion
             globality-build bump-version


### PR DESCRIPTION
## Why?
Currently, we cannot publish open source codes to PyPI due to missing the credential.  

## What?
We add a token to CircleCI to allow publishing this open source codes to PyPI.  With a token, the file format for upload to PyPI is documented here (https://packaging.python.org/specifications/pypirc/)

