### PR TITLE
Setting long_description content type, hopefully enabling pypi publishing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
     ],
     description="A wrapper for black adding new features",
     long_description=readme + "\n\n" + history,
+    long_description_content_type='text/markdown',
     url="https://github.com/globality-corp/globality-black",
     keywords="globality_black",
     entry_points={

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     ],
     description="A wrapper for black adding new features",
     long_description=readme + "\n\n" + history,
-    long_description_content_type='text/markdown',
+    long_description_content_type="text/markdown",
     url="https://github.com/globality-corp/globality-black",
     keywords="globality_black",
     entry_points={


### PR DESCRIPTION
Setting `long_description_content_type` in `setup.py` to its correct value - Markdown. 

## Why?

Otherwise `twine` fails to upload the package to pypi
