### PR TITLE
Cover more cases for blank_lines

### DIFF
--- a/globality_black/constants.py
+++ b/globality_black/constants.py
@@ -2,7 +2,7 @@ from enum import Enum, unique
 
 
 BLANK_LINE_TOKEN = "TOKEN"
-BLANK_LINES_TYPES = ["arglist", "expr_stmt", "atom_expr"]
+BLANK_LINES_TYPES = ["arglist", "expr_stmt", "atom_expr", "atom"]
 COMPREHENSIONS_TYPES = ["comp_if", "sync_comp_for"]
 TYPES_TO_CHECK_FMT_ON_OFF = ("stmt", "funcdef", "classdef")
 MAX_CHARACTERS_TO_FIND_INDENTATION_PARENT = 200

--- a/globality_black/tests/fixtures/blank_lines_input.txt
+++ b/globality_black/tests/fixtures/blank_lines_input.txt
@@ -110,15 +110,15 @@ class A:
         )
 
 
-def is_valid_node(node):
+def is_valid_food(food):
     return (
-        node.tag not in ELEMENTS_TO_REMOVE
+        food.ingredient not in INGREDIENTS_TO_REMOVE
 
-        # remove any hidden text
-        and not node.get("aria-hidden")
-        and not node.get("type") == "hidden"
-        and node.get("hidden") is None
+        # remove any spicy food
+        and not food.get("spicy")
+        and not food.get("condiment") == "soya"
+        and food.get("extra") is None
 
-        # avoid style="display: none"
-        and read_css_dict(node.get("style")).get("display") != "none"
+        # avoid sauce="none"
+        and sauce is None
     )

--- a/globality_black/tests/fixtures/blank_lines_input.txt
+++ b/globality_black/tests/fixtures/blank_lines_input.txt
@@ -108,3 +108,17 @@ class A:
             # at least `z` bla bla
             >= z
         )
+
+
+def is_valid_node(node):
+    return (
+        node.tag not in ELEMENTS_TO_REMOVE
+
+        # remove any hidden text
+        and not node.get("aria-hidden")
+        and not node.get("type") == "hidden"
+        and node.get("hidden") is None
+
+        # avoid style="display: none"
+        and read_css_dict(node.get("style")).get("display") != "none"
+    )

--- a/globality_black/tests/fixtures/blank_lines_output.txt
+++ b/globality_black/tests/fixtures/blank_lines_output.txt
@@ -100,15 +100,15 @@ class A:
         )
 
 
-def is_valid_node(node):
+def is_valid_food(food):
     return (
-        node.tag not in ELEMENTS_TO_REMOVE
+        food.ingredient not in INGREDIENTS_TO_REMOVE
 
-        # remove any hidden text
-        and not node.get("aria-hidden")
-        and not node.get("type") == "hidden"
-        and node.get("hidden") is None
+        # remove any spicy food
+        and not food.get("spicy")
+        and not food.get("condiment") == "soya"
+        and food.get("extra") is None
 
-        # avoid style="display: none"
-        and read_css_dict(node.get("style")).get("display") != "none"
+        # avoid sauce="none"
+        and sauce is None
     )

--- a/globality_black/tests/fixtures/blank_lines_output.txt
+++ b/globality_black/tests/fixtures/blank_lines_output.txt
@@ -98,3 +98,17 @@ class A:
             # at least `z` bla bla
             >= z
         )
+
+
+def is_valid_node(node):
+    return (
+        node.tag not in ELEMENTS_TO_REMOVE
+
+        # remove any hidden text
+        and not node.get("aria-hidden")
+        and not node.get("type") == "hidden"
+        and node.get("hidden") is None
+
+        # avoid style="display: none"
+        and read_css_dict(node.get("style")).get("display") != "none"
+    )


### PR DESCRIPTION
<!-- Describe the issue -->

Improving the `blank_lines` feature so that blank lines before comments are not removed, see examples in tests, and/or answer https://github.com/globality-corp/globality-black/pull/7#issuecomment-776598426
Closes [GLOB-51226]


## Why?

<!-- What's the goal of the change? -->

To cover cases like the ones added to the test

## What?

- Add another type to BLANK_LINE_TYPES

[GLOB-51226]: https://globality.atlassian.net/browse/GLOB-51226