### PR TITLE
Glob 52048/show only errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,11 @@ to better align with Globality conventions.
  
 Note: if you are not familiar with black (or need a refresh), please read our [Black refresh](#black-refresh).
 
+Cli
+--------
+
+Please see command line arguments running `globality-black --help`. 
+
 Features
 --------
 

--- a/globality_black/cli.py
+++ b/globality_black/cli.py
@@ -24,23 +24,28 @@ def main(path, check, verbose):
     """
     Run globality-black for a given path
 
-    path:
+    \b
+    * path:
         If path is a directory, apply to all .py files in any subdirectory
-        Otherwise, apply just to the given filename
+        Otherwise, apply just to the given filename.
 
-    check:
-        If --check is passed, do not modify the files and return
-            exit code 1: if any file needs to be reformatted (or fails when applying black)
-            exit code 0: otherwise
-
+    \b
+    * check:
+        If --check is passed, do not modify the files and return:
+            - exit code 1: if any file needs to be reformatted (or fails when applying black)
+            - exit code 0: otherwise
+        \b
         If --check not passed (or --no-check is passed), attempt to reformat all paths returning
             - exit code 1: if any file fails
             - exit code 0: otherwise
-
+        \b
         Note that when not passing --check, all files not failing will be correctly reformatted
         (i.e. globality-black is independently applied per-file)
 
-        If --verbose not passed (or --no-verbose), only files with errors are shown when check
+    \b
+    * verbose:
+        If --verbose not passed (or --no-verbose), only files with errors or to be modified are
+        shown
 
     """
 

--- a/globality_black/cli.py
+++ b/globality_black/cli.py
@@ -20,6 +20,8 @@ from globality_black.reformat_text import BlackError, reformat_text
 @click.argument("path", type=click.Path(readable=True, writable=True, exists=True))
 @click.option("--check/--no-check", type=bool, default=False)
 @click.option("--verbose/--no-verbose", type=bool, default=False)
+# characters \b needed to avoid click reformatting
+# see https://click.palletsprojects.com/en/7.x/documentation/#preventing-rewrapping
 def main(path, check, verbose):
     """
     Run globality-black for a given path

--- a/globality_black/cli.py
+++ b/globality_black/cli.py
@@ -71,7 +71,7 @@ def main(path, check, verbose):
         map_result = map(process_path_with_check, paths)
 
     for is_modified, is_failed, message in map_result:
-        if verbose or not message.startswith("Nothing to do for"):
+        if verbose or is_modified or is_failed:
             click.echo(message)
         reformatted_count += is_modified
         failed_count += is_failed

--- a/globality_black/cli.py
+++ b/globality_black/cli.py
@@ -19,7 +19,8 @@ from globality_black.reformat_text import BlackError, reformat_text
 @click.command()
 @click.argument("path", type=click.Path(readable=True, writable=True, exists=True))
 @click.option("--check/--no-check", type=bool, default=False)
-def main(path, check):
+@click.option("--verbose/--no-verbose", type=bool, default=False)
+def main(path, check, verbose):
     """
     Run globality-black for a given path
 
@@ -38,6 +39,8 @@ def main(path, check):
 
         Note that when not passing --check, all files not failing will be correctly reformatted
         (i.e. globality-black is independently applied per-file)
+
+        If --verbose not passed (or --no-verbose), only files with errors are shown when check
 
     """
 
@@ -61,7 +64,8 @@ def main(path, check):
         map_result = map(process_path_with_check, paths)
 
     for is_modified, is_failed, message in map_result:
-        click.echo(message)
+        if verbose or not message.startswith("Nothing to do for"):
+            click.echo(message)
         reformatted_count += is_modified
         failed_count += is_failed
 

--- a/globality_black/tests/test_cli.py
+++ b/globality_black/tests/test_cli.py
@@ -29,8 +29,9 @@ SINGLE_FILE_MAP = {
 
 
 @pytest.mark.parametrize("check", (False, True))
+@pytest.mark.parametrize("verbose", (False, True))
 @pytest.mark.parametrize("file_condition", tuple(FileCondition))
-def test_cli_file(runner: CliRunner, check: bool, file_condition: FileCondition):
+def test_cli_file(runner: CliRunner, check: bool, verbose: bool, file_condition: FileCondition):
     """
     We copy the input file to a temp directory, change the extension to .py and use
     globality-black
@@ -52,7 +53,7 @@ def test_cli_file(runner: CliRunner, check: bool, file_condition: FileCondition)
         input_path = (Path(temp_path) / file_to_test_cli).with_suffix(".py")
         shutil.copy(str(fixture_input_path), str(input_path))
 
-        result = run_globality_black(runner, input_path, check)
+        result = run_globality_black(runner, input_path, check, verbose)
         expected_exit_code = 1 if has_errors or check and needs_gb else 0
         assert result.exit_code == expected_exit_code
 
@@ -66,14 +67,22 @@ def test_cli_file(runner: CliRunner, check: bool, file_condition: FileCondition)
 
         per_file_string, final_count_string = get_strings(check, file_condition)
 
-        pattern = f"{per_file_string} {input_path}.*{emoji}.*1 files {final_count_string}.*"
+        if verbose:
+            pattern = f"{per_file_string} {input_path}.*{emoji}.*1 files {final_count_string}.*"
+        else:
+            # TODO: need to continue here !!
+            pattern = f"{per_file_string} {input_path}.*{emoji}.*1 files {final_count_string}.*"
         assert re.match(pattern, result.output, flags=re.DOTALL)
 
 
-def run_globality_black(runner: CliRunner, path: Path, check: bool):
+def run_globality_black(runner: CliRunner, path: Path, check: bool, verbose: bool):
     args = [str(path)]
     if check:
         args.append("--check")
+
+    if verbose:
+        args.append("--verbose")
+
     result = run_and_check(
         runner=runner,
         command_name="globality-black",


### PR DESCRIPTION
<!-- Describe the issue -->

This quick PR aims to improve two areas:

- Only show files that need gblack or have errors when running a directory
- Better docs and help when `globality-black --help`

Closes [GLOB-52048]


## Why?

See the Jira task for a longer description

[GLOB-52048]: https://globality.atlassian.net/browse/GLOB-52048