### PR TITLE
STDIN handling more consistent with black

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -4,4 +4,4 @@ from click.testing import CliRunner
 
 @pytest.fixture
 def runner():
-    return CliRunner()
+    return CliRunner(mix_stderr=False)

--- a/globality_black/cli.py
+++ b/globality_black/cli.py
@@ -61,12 +61,9 @@ def main(src, check: bool, diff: bool, verbose: bool):
         If --diff, do not modify the files and display the changes induced by reformatting
 
     """
+    messages_to_stderr = True  # consistent with black
     path = Path(src)
     assert path.exists() or path == STDIN_PATH, f"Path {path} does not exist"
-
-    # if we are reading from stdin, we should print system messages to stderr,
-    # as stdout is used to print the reformatted code
-    messages_output = sys.stderr if path == STDIN_PATH else sys.stdout
 
     exit_code = 0
     if diff:
@@ -89,34 +86,36 @@ def main(src, check: bool, diff: bool, verbose: bool):
 
     for is_modified, is_failed, message in map_result:  # type: ignore
         if verbose or is_modified or is_failed:
-            click.echo(message, file=messages_output)
+            click.echo(message, err=messages_to_stderr)
         reformatted_count += is_modified
         failed_count += is_failed
 
     unchanged_count = len(paths) - reformatted_count - failed_count
 
     # add a separator line
-    click.echo("-" * len(OH_NO_STRING), file=messages_output)
+    click.echo("-" * len(OH_NO_STRING), err=messages_to_stderr)
 
     # if we are just checking and at least one file needs to be reformatted OR some file failed
     if (check and reformatted_count > 0) or failed_count > 0:
-        click.echo(OH_NO_STRING, file=messages_output)
+        click.echo(OH_NO_STRING, err=messages_to_stderr)
         exit_code = 1
         if failed_count > 0:
-            click.echo(f"{failed_count} files failed to parse (black error)", file=messages_output)
+            click.echo(
+                f"{failed_count} files failed to parse (black error)", err=messages_to_stderr
+            )
     else:
-        click.echo(ALL_DONE_STRING, file=messages_output)
+        click.echo(ALL_DONE_STRING, err=messages_to_stderr)
 
     if check:
         if reformatted_count > 0:
-            click.echo(f"{reformatted_count} files would be reformatted", file=messages_output)
+            click.echo(f"{reformatted_count} files would be reformatted", err=messages_to_stderr)
         if unchanged_count > 0:
-            click.echo(f"{unchanged_count} files would be left unchanged", file=messages_output)
+            click.echo(f"{unchanged_count} files would be left unchanged", err=messages_to_stderr)
     else:
         if reformatted_count > 0:
-            click.echo(f"{reformatted_count} files reformatted", file=messages_output)
+            click.echo(f"{reformatted_count} files reformatted", err=messages_to_stderr)
         if unchanged_count > 0:
-            click.echo(f"{unchanged_count} files unchanged", file=messages_output)
+            click.echo(f"{unchanged_count} files unchanged", err=messages_to_stderr)
 
     sys.exit(exit_code)
 

--- a/globality_black/cli.py
+++ b/globality_black/cli.py
@@ -159,7 +159,8 @@ def process_src(
     if not check_only_mode and file_mode:
         path.write_text(output_code)  # type: ignore
     if not check_only_mode and not file_mode:
-        click.echo(output_code, file=sys.stdout, nl=False)
+        # input provided via stdin - we print the reformatted code
+        click.echo(output_code, nl=False)
 
     path_str = f" {path}" if file_mode else ""
     if diff_mode:

--- a/globality_black/cli.py
+++ b/globality_black/cli.py
@@ -159,7 +159,7 @@ def process_src(
     if not check_only_mode and file_mode:
         path.write_text(output_code)  # type: ignore
     if not check_only_mode and not file_mode:
-        click.echo(output_code, file=sys.stdout)
+        click.echo(output_code, file=sys.stdout, nl=False)
 
     path_str = f" {path}" if file_mode else ""
     if diff_mode:

--- a/globality_black/constants.py
+++ b/globality_black/constants.py
@@ -1,4 +1,5 @@
 from enum import Enum, unique
+from pathlib import Path
 
 
 @unique
@@ -26,3 +27,5 @@ NUM_FILES_TO_ENABLE_PARALLELIZATION = 5
 TAB_CHAR_SIZE = 4
 ALL_DONE_STRING = "All done! ✨ 🍰 ✨"
 OH_NO_STRING = "Oh no! 💥 💔 💥"
+
+STDIN_PATH = Path("-")

--- a/globality_black/tests/__init__.py
+++ b/globality_black/tests/__init__.py
@@ -1,6 +1,6 @@
 import difflib
 import logging
-from typing import Sequence
+from typing import Optional, Sequence
 
 import click
 from click.testing import CliRunner, Result
@@ -36,7 +36,8 @@ def run_and_check(
     command_name: str,
     command: click.Command,
     args: Sequence[str],
+    input: Optional[str],
 ) -> Result:
     logging.info(f"Running command: {command_name} {' '.join(args)}")
-    result = runner.invoke(command, args)
+    result = runner.invoke(command, args, input=input)
     return result


### PR DESCRIPTION
Goals:
- make the interface more consistent with `black`
- avoid having a separate code path for "code" mode and "normal" mode - therefore avoiding duplication of code
- ... by doing the above, we can actually combine the STDIN input with all the modes - like `--diff` and `--check`

Changes:
- "system messages" about success/failure etc are now consistently printed to STDERR - like `black` does. This leaves STDOUT free of clutter, so formatted code can be printed there if input was given by STDIN
- removed the `--code` option - as in `black` that is used when passing source code **inside the command** - yet another interface. The option is also not needed.
- instead, using the (already enabled, but not handled) `allow_dash` feature in `src: click.Path`. Instead of specifying the path argument, the user can end the command with ` - `, and then provide the input to STDIN. `click` can handle it like a file path, using `open_file()`

Additionally:
- added tests for the STDIN mode
- some very small renamings/reorderings
